### PR TITLE
chore: migrate delete handler to slack edge

### DIFF
--- a/src/features/deleteHandler.ts
+++ b/src/features/deleteHandler.ts
@@ -1,4 +1,3 @@
-import * as FormData from "form-data";
 import { App } from "@slack/bolt";
 import fetch from "node-fetch";
 import config from "../config";
@@ -9,15 +8,13 @@ async function deleteEmoji(emojiName: string, user: string) {
     form.append("_x_reason", "customize-emoji-remove");
     form.append("_x_mode", "online");
     form.append("name", emojiName);
-    form.append("token", process.env.SLACK_BOT_USER_TOKEN);
+    form.append("token", process.env.SLACK_BOT_USER_TOKEN!);
     const res = await fetch("https://thepurplebubble.slack.com/api/emoji.remove", {
         method: "POST",
         headers: {
-            ...config.reqHeaders,
-            "Content-Length": form.getLengthSync().toString(),
-            ...form.getHeaders(),
+            Cookie: `Cookie ${process.env.SLACK_COOKIE}`,
         },
-        body: form.getBuffer(),
+        body: form,
     }).then((res) => res.json() as Promise<{ ok: boolean }>);
     return res.ok
         ? `:${emojiName}: has been removed, thanks <@${user}>!`
@@ -32,15 +29,14 @@ const feature3 = async (app: SlackApp<{
     SLACK_BOT_TOKEN: string;
     SLACK_APP_TOKEN: string;
 }>) => {
-    app.view("delete_view", async ({ client, ack, view }) => {
-        await ack();
-        const meta = JSON.parse(view.private_metadata) as {
+    app.view("delete_view", async () => { }, async ({ context, payload }) => {
+        const meta = JSON.parse(payload.view.private_metadata) as {
             emoji: string;
             thread_ts: string;
             user: string;
         };
         const status = await deleteEmoji(meta.emoji, meta.user);
-        await client.chat.postMessage({
+        await context.client.chat.postMessage({
             channel: config.channel,
             thread_ts: meta.thread_ts,
             text: status,


### PR DESCRIPTION
### TL;DR
Refactored `deleteHandler.ts` to remove the `form-data` package as its provided natively by Bun; also migrated to slack edge
