### PR TITLE
chore: move slack workspace to the config file

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -1,23 +1,6 @@
 const config = {
     channel: "C078WHPFMJT",
-    reqHeaders: {
-        "User-Agent":
-            "Mozilla/5.0 (Windows NT 11.0; WOW64; x64; rv:93.0esr) Gecko/20010101 Firefox/93.0esr/Yp6557blmseFJz",
-        Accept: "*/*",
-        "Accept-Language": "en-US,en;q=0.5",
-        "Sec-Fetch-Dest": "empty",
-        "Sec-Fetch-Mode": "cors",
-        "Sec-Fetch-Site": "same-site",
-        "Sec-GPC": "1",
-        Pragma: "no-cache",
-        "Cache-Control": "no-cache",
-        Cookie: process.env.SLACK_COOKIE,
-        TE: "trailers",
-        Origin: "https://app.slack.com",
-        Host: "thepurplebubble.slack.com",
-        DNT: "1",
-        Connection: "keep-alive",
-    },
+    slackWorkspace: "thepurplebubble",
     admins: ["U079PPPT189"],
 };
 

--- a/src/features/deleteHandler.ts
+++ b/src/features/deleteHandler.ts
@@ -11,7 +11,7 @@ async function deleteEmoji(emojiName: string, user: string) {
     form.append("name", emojiName);
     form.append("token", process.env.SLACK_BOT_USER_TOKEN!);
     const res = await fetch(
-        "https://thepurplebubble.slack.com/api/emoji.remove",
+        `https://${config.slackWorkspace}.slack.com/api/emoji.remove`,
         {
             method: "POST",
             headers: {

--- a/src/features/uploader.ts
+++ b/src/features/uploader.ts
@@ -54,7 +54,7 @@ const feature1 = async (
 
         // No idea how much of this is necessary but I don't feel like figuring it out
         const res = await fetch(
-            "https://thepurplebubble.slack.com/api/emoji.add",
+            `https://${config.slackWorkspace}.slack.com/api/emoji.add`,
             {
                 credentials: "include",
                 method: "POST",


### PR DESCRIPTION
### TL;DR
Replaced instances of hard-coded Slack workspace URL with a dynamic value, fetched from the `config.slackWorkspace` property.

### What changed?
- In `config.ts`, removed `reqHeaders` and added `slackWorkspace` property.
- Updated `deleteHandler.ts` and `uploader.ts` to use the `config.slackWorkspace` for constructing Slack workspace URLs.

### How to test?
1. Ensure that the `config.slackWorkspace` property is correctly set.
2. Run the application and observe if requests are correctly made to the Slack workspace specified in `config.slackWorkspace`.

### Why make this change?
To make the Slack workspace URL dynamic and configurable, reducing hard-coded values and enhancing flexibility in different environments.

---

